### PR TITLE
make texas.zsh executable

### DIFF
--- a/texas.zsh
+++ b/texas.zsh
@@ -1,3 +1,4 @@
+#!/bin/zsh
 # -*- sh -*-
 
 # Start a new tmux session with texas inside.


### PR DESCRIPTION
This commits makes texas.zsh executable and adds a shebang so that texas.zsh can be executed directly.
My reason for doing this: In [Rofi](https://davedavenport.github.io/rofi/) I use a [custom script](https://github.com/teranex/awesome-config/blob/master/scripts/rofi-dirs) to list my most commonly used directories and quickly open them in the file manager. I now switched this to launch Texas, but simply running `terminator -e texas` doesn't work (I guess because `$fpath` is not defined in that case?). Running `terminator -e /path/to/texas.zsh` works without any problems. I don't think this has any side-effects.